### PR TITLE
:package: Fix MpsTransaction Syntax Error

### DIFF
--- a/lib/Model/MpsTransaction.php
+++ b/lib/Model/MpsTransaction.php
@@ -228,7 +228,7 @@ class MpsTransaction implements ArrayAccess
             $invalid_properties[] = "'mps_payment_type' can't be null";
         }
         $allowed_values = $this->getMpsPaymentTypeAllowableValues();
-        if ($this->container['mps_payment_type'], $allowed_values) {
+        if (!in_array($this->container['mps_payment_type'], $allowed_values)) {
             $invalid_properties[] = sprintf(
                 "invalid value for 'mps_payment_type', must be one of '%s'",
                 implode("', '", $allowed_values)


### PR DESCRIPTION
### Problem
A contributor accidentally added a syntax error, without noticing it.
This caused some problems on our end.

### Solution 
Add the missing `in_array` function that should have been there.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206635081723931
  - https://app.asana.com/0/0/1206635081723937